### PR TITLE
Set the sign-in/sign-up components to link to each other

### DIFF
--- a/pages/sign-in.vue
+++ b/pages/sign-in.vue
@@ -8,6 +8,6 @@ definePageMeta({
 
 <template>
   <div class="grid h-full place-items-center">
-    <SignIn />
+    <SignIn sign-up-url="/sign-up" />
   </div>
 </template>

--- a/pages/sign-up.vue
+++ b/pages/sign-up.vue
@@ -8,6 +8,6 @@ definePageMeta({
 
 <template>
   <div class="grid h-full place-items-center">
-    <SignUp />
+    <SignUp sign-in-url="/sign-in" />
   </div>
 </template>


### PR DESCRIPTION
I'd like to propose this small change so that when a user goes to the "/sign-in" route (or "/sign-up") and clicks on the Sign Up link on the <SignIn /> component it keeps the user in the Nuxt app rather than sending them out to the Clerk domain.